### PR TITLE
Remove failing package command from prerequisites, fix module names within part2/3/4

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ Next step, let's pre-download as much required maven dependencies as possible, f
 cd "${CQ_WORKSHOP_DIRECTORY}/camel-quarkus-workshop"
 mvn quarkus:go-offline -fae
 mvn dependency:go-offline -fae
-mvn clean package -fae
 cd part-2-jvm-mode
 mvn clean quarkus:dev
 ```

--- a/part-2-jvm-mode/README.md
+++ b/part-2-jvm-mode/README.md
@@ -1,4 +1,4 @@
-# part-1-cq-dev-mode Project
+# part-2-jvm-mode Project
 
 This project uses Quarkus, the Supersonic Subatomic Java Framework.
 
@@ -43,6 +43,6 @@ Or, if you don't have GraalVM installed, you can run the native executable build
 ./mvnw package -Pnative -Dquarkus.native.container-build=true
 ```
 
-You can then execute your native executable with: `./target/part-1-cq-dev-mode-1.0.0-SNAPSHOT-runner`
+You can then execute your native executable with: `./target/part-2-jvm-mode-1.0.0-SNAPSHOT-runner`
 
 If you want to learn more about building native executables, please consult https://quarkus.io/guides/maven-tooling.html.

--- a/part-2-jvm-mode/src/main/docker/Dockerfile.jvm
+++ b/part-2-jvm-mode/src/main/docker/Dockerfile.jvm
@@ -7,18 +7,18 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/part-1-cq-dev-mode-jvm .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/part-2-jvm-mode-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode-jvm
+# docker run -i --rm -p 8080:8080 quarkus/part-2-jvm-mode-jvm
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-1-cq-dev-mode-jvm
+# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-2-jvm-mode-jvm
 #
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 

--- a/part-2-jvm-mode/src/main/docker/Dockerfile.legacy-jar
+++ b/part-2-jvm-mode/src/main/docker/Dockerfile.legacy-jar
@@ -7,18 +7,18 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.legacy-jar -t quarkus/part-1-cq-dev-mode-legacy-jar .
+# docker build -f src/main/docker/Dockerfile.legacy-jar -t quarkus/part-2-jvm-mode-legacy-jar .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode-legacy-jar
+# docker run -i --rm -p 8080:8080 quarkus/part-2-jvm-mode-legacy-jar
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-1-cq-dev-mode-legacy-jar
+# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-2-jvm-mode-legacy-jar
 #
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 

--- a/part-2-jvm-mode/src/main/docker/Dockerfile.native
+++ b/part-2-jvm-mode/src/main/docker/Dockerfile.native
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native -t quarkus/part-1-cq-dev-mode .
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/part-2-jvm-mode .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode
+# docker run -i --rm -p 8080:8080 quarkus/part-2-jvm-mode
 #
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4

--- a/part-2-jvm-mode/src/main/docker/Dockerfile.native-distroless
+++ b/part-2-jvm-mode/src/main/docker/Dockerfile.native-distroless
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native-distroless -t quarkus/part-1-cq-dev-mode .
+# docker build -f src/main/docker/Dockerfile.native-distroless -t quarkus/part-2-jvm-mode .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode
+# docker run -i --rm -p 8080:8080 quarkus/part-2-jvm-mode
 #
 ###
 FROM quay.io/quarkus/quarkus-distroless-image:1.0

--- a/part-3-native-mode/README.md
+++ b/part-3-native-mode/README.md
@@ -1,4 +1,4 @@
-# part-1-cq-dev-mode Project
+# part-3-native-mode Project
 
 This project uses Quarkus, the Supersonic Subatomic Java Framework.
 
@@ -43,6 +43,6 @@ Or, if you don't have GraalVM installed, you can run the native executable build
 ./mvnw package -Pnative -Dquarkus.native.container-build=true
 ```
 
-You can then execute your native executable with: `./target/part-1-cq-dev-mode-1.0.0-SNAPSHOT-runner`
+You can then execute your native executable with: `./target/part-3-native-mode-1.0.0-SNAPSHOT-runner`
 
 If you want to learn more about building native executables, please consult https://quarkus.io/guides/maven-tooling.html.

--- a/part-3-native-mode/src/main/docker/Dockerfile.jvm
+++ b/part-3-native-mode/src/main/docker/Dockerfile.jvm
@@ -7,18 +7,18 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/part-1-cq-dev-mode-jvm .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/part-3-native-mode-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode-jvm
+# docker run -i --rm -p 8080:8080 quarkus/part-3-native-mode-jvm
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-1-cq-dev-mode-jvm
+# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-3-native-mode-jvm
 #
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 

--- a/part-3-native-mode/src/main/docker/Dockerfile.legacy-jar
+++ b/part-3-native-mode/src/main/docker/Dockerfile.legacy-jar
@@ -7,18 +7,18 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.legacy-jar -t quarkus/part-1-cq-dev-mode-legacy-jar .
+# docker build -f src/main/docker/Dockerfile.legacy-jar -t quarkus/part-3-native-mode-legacy-jar .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode-legacy-jar
+# docker run -i --rm -p 8080:8080 quarkus/part-3-native-mode-legacy-jar
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-1-cq-dev-mode-legacy-jar
+# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-3-native-mode-legacy-jar
 #
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 

--- a/part-3-native-mode/src/main/docker/Dockerfile.native
+++ b/part-3-native-mode/src/main/docker/Dockerfile.native
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native -t quarkus/part-1-cq-dev-mode .
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/part-3-native-mode .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode
+# docker run -i --rm -p 8080:8080 quarkus/part-3-native-mode
 #
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4

--- a/part-3-native-mode/src/main/docker/Dockerfile.native-distroless
+++ b/part-3-native-mode/src/main/docker/Dockerfile.native-distroless
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native-distroless -t quarkus/part-1-cq-dev-mode .
+# docker build -f src/main/docker/Dockerfile.native-distroless -t quarkus/part-3-native-mode .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode
+# docker run -i --rm -p 8080:8080 quarkus/part-3-native-mode
 #
 ###
 FROM quay.io/quarkus/quarkus-distroless-image:1.0

--- a/part-4-routes/README.md
+++ b/part-4-routes/README.md
@@ -1,4 +1,4 @@
-# part-1-cq-dev-mode Project
+# part-4-routes Project
 
 This project uses Quarkus, the Supersonic Subatomic Java Framework.
 
@@ -43,6 +43,6 @@ Or, if you don't have GraalVM installed, you can run the native executable build
 ./mvnw package -Pnative -Dquarkus.native.container-build=true
 ```
 
-You can then execute your native executable with: `./target/part-1-cq-dev-mode-1.0.0-SNAPSHOT-runner`
+You can then execute your native executable with: `./target/part-4-routes-1.0.0-SNAPSHOT-runner`
 
 If you want to learn more about building native executables, please consult https://quarkus.io/guides/maven-tooling.html.

--- a/part-4-routes/src/main/docker/Dockerfile.jvm
+++ b/part-4-routes/src/main/docker/Dockerfile.jvm
@@ -7,18 +7,18 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/part-1-cq-dev-mode-jvm .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/part-4-routes-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode-jvm
+# docker run -i --rm -p 8080:8080 quarkus/part-4-routes-jvm
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-1-cq-dev-mode-jvm
+# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-4-routes-jvm
 #
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 

--- a/part-4-routes/src/main/docker/Dockerfile.legacy-jar
+++ b/part-4-routes/src/main/docker/Dockerfile.legacy-jar
@@ -7,18 +7,18 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.legacy-jar -t quarkus/part-1-cq-dev-mode-legacy-jar .
+# docker build -f src/main/docker/Dockerfile.legacy-jar -t quarkus/part-4-routes-legacy-jar .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode-legacy-jar
+# docker run -i --rm -p 8080:8080 quarkus/part-4-routes-legacy-jar
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-1-cq-dev-mode-legacy-jar
+# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-4-routes-legacy-jar
 #
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 

--- a/part-4-routes/src/main/docker/Dockerfile.native
+++ b/part-4-routes/src/main/docker/Dockerfile.native
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native -t quarkus/part-1-cq-dev-mode .
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/part-4-routes .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode
+# docker run -i --rm -p 8080:8080 quarkus/part-4-routes
 #
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4

--- a/part-4-routes/src/main/docker/Dockerfile.native-distroless
+++ b/part-4-routes/src/main/docker/Dockerfile.native-distroless
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native-distroless -t quarkus/part-1-cq-dev-mode .
+# docker build -f src/main/docker/Dockerfile.native-distroless -t quarkus/part-4-routes .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode
+# docker run -i --rm -p 8080:8080 quarkus/part-4-routes
 #
 ###
 FROM quay.io/quarkus/quarkus-distroless-image:1.0

--- a/part-5-extensions/README.md
+++ b/part-5-extensions/README.md
@@ -1,4 +1,4 @@
-# part-1-cq-dev-mode Project
+# part-5-extensions Project
 
 This project uses Quarkus, the Supersonic Subatomic Java Framework.
 
@@ -43,6 +43,6 @@ Or, if you don't have GraalVM installed, you can run the native executable build
 ./mvnw package -Pnative -Dquarkus.native.container-build=true
 ```
 
-You can then execute your native executable with: `./target/part-1-cq-dev-mode-1.0.0-SNAPSHOT-runner`
+You can then execute your native executable with: `./target/part-5-extensions-1.0.0-SNAPSHOT-runner`
 
 If you want to learn more about building native executables, please consult https://quarkus.io/guides/maven-tooling.html.

--- a/part-5-extensions/src/main/docker/Dockerfile.jvm
+++ b/part-5-extensions/src/main/docker/Dockerfile.jvm
@@ -7,18 +7,18 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/part-1-cq-dev-mode-jvm .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/part-5-extensions-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode-jvm
+# docker run -i --rm -p 8080:8080 quarkus/part-5-extensions-jvm
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-1-cq-dev-mode-jvm
+# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-5-extensions-jvm
 #
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 

--- a/part-5-extensions/src/main/docker/Dockerfile.legacy-jar
+++ b/part-5-extensions/src/main/docker/Dockerfile.legacy-jar
@@ -7,18 +7,18 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.legacy-jar -t quarkus/part-1-cq-dev-mode-legacy-jar .
+# docker build -f src/main/docker/Dockerfile.legacy-jar -t quarkus/part-5-extensions-legacy-jar .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode-legacy-jar
+# docker run -i --rm -p 8080:8080 quarkus/part-5-extensions-legacy-jar
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-1-cq-dev-mode-legacy-jar
+# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-5-extensions-legacy-jar
 #
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 

--- a/part-5-extensions/src/main/docker/Dockerfile.native
+++ b/part-5-extensions/src/main/docker/Dockerfile.native
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native -t quarkus/part-1-cq-dev-mode .
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/part-5-extensions .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode
+# docker run -i --rm -p 8080:8080 quarkus/part-5-extensions
 #
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4

--- a/part-5-extensions/src/main/docker/Dockerfile.native-distroless
+++ b/part-5-extensions/src/main/docker/Dockerfile.native-distroless
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native-distroless -t quarkus/part-1-cq-dev-mode .
+# docker build -f src/main/docker/Dockerfile.native-distroless -t quarkus/part-5-extensions .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode
+# docker run -i --rm -p 8080:8080 quarkus/part-5-extensions
 #
 ###
 FROM quay.io/quarkus/quarkus-distroless-image:1.0

--- a/part-6-eips/README.md
+++ b/part-6-eips/README.md
@@ -1,4 +1,4 @@
-# part-1-cq-dev-mode Project
+# part-6-eips Project
 
 This project uses Quarkus, the Supersonic Subatomic Java Framework.
 
@@ -43,6 +43,6 @@ Or, if you don't have GraalVM installed, you can run the native executable build
 ./mvnw package -Pnative -Dquarkus.native.container-build=true
 ```
 
-You can then execute your native executable with: `./target/part-1-cq-dev-mode-1.0.0-SNAPSHOT-runner`
+You can then execute your native executable with: `./target/part-6-eips-1.0.0-SNAPSHOT-runner`
 
 If you want to learn more about building native executables, please consult https://quarkus.io/guides/maven-tooling.html.

--- a/part-6-eips/src/main/docker/Dockerfile.jvm
+++ b/part-6-eips/src/main/docker/Dockerfile.jvm
@@ -7,18 +7,18 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/part-1-cq-dev-mode-jvm .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/part-6-eips-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode-jvm
+# docker run -i --rm -p 8080:8080 quarkus/part-6-eips-jvm
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-1-cq-dev-mode-jvm
+# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-6-eips-jvm
 #
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 

--- a/part-6-eips/src/main/docker/Dockerfile.legacy-jar
+++ b/part-6-eips/src/main/docker/Dockerfile.legacy-jar
@@ -7,18 +7,18 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.legacy-jar -t quarkus/part-1-cq-dev-mode-legacy-jar .
+# docker build -f src/main/docker/Dockerfile.legacy-jar -t quarkus/part-6-eips-legacy-jar .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode-legacy-jar
+# docker run -i --rm -p 8080:8080 quarkus/part-6-eips-legacy-jar
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5005
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-1-cq-dev-mode-legacy-jar
+# docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/part-6-eips-legacy-jar
 #
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 

--- a/part-6-eips/src/main/docker/Dockerfile.native
+++ b/part-6-eips/src/main/docker/Dockerfile.native
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native -t quarkus/part-1-cq-dev-mode .
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/part-6-eips .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode
+# docker run -i --rm -p 8080:8080 quarkus/part-6-eips
 #
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4

--- a/part-6-eips/src/main/docker/Dockerfile.native-distroless
+++ b/part-6-eips/src/main/docker/Dockerfile.native-distroless
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native-distroless -t quarkus/part-1-cq-dev-mode .
+# docker build -f src/main/docker/Dockerfile.native-distroless -t quarkus/part-6-eips .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/part-1-cq-dev-mode
+# docker run -i --rm -p 8080:8080 quarkus/part-6-eips
 #
 ###
 FROM quay.io/quarkus/quarkus-distroless-image:1.0


### PR DESCRIPTION
- The maven clean package command in prerequisites fails at the beginning because we haven't done the fixes to the routes in part-4 - I think it might be less confusing if that is removed from the setup
- fixed some label issues with part 2-6